### PR TITLE
Initialize skeleton Next.js novel editor app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
-# new_novel_editor
+# Novel Editor App
+
+This repository contains a skeleton implementation of a web application for writing and managing novels.
+
+The app is built with Next.js and Tailwind CSS. Due to the offline environment, dependencies are not installed and the project serves as a starting point for further development.
+
+## Directory Structure
+
+- `novel-editor-app/` - source code for the Next.js application
+
+To set up the project in a fully online environment, install the dependencies using `npm install` and start the development server with `npm run dev`.

--- a/novel-editor-app/.env
+++ b/novel-editor-app/.env
@@ -1,0 +1,1 @@
+# Add your environment variables here

--- a/novel-editor-app/next-env.d.ts
+++ b/novel-editor-app/next-env.d.ts
@@ -1,0 +1,8 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+/// <reference types="next/navigation-types/compat/navigation" />
+
+declare module '*.svg' {
+  const content: any;
+  export default content;
+}

--- a/novel-editor-app/next.config.js
+++ b/novel-editor-app/next.config.js
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+}
+
+module.exports = nextConfig

--- a/novel-editor-app/package.json
+++ b/novel-editor-app/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "novel-editor-app",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "@tiptap/core": "^2.0.0",
+    "@tiptap/react": "^2.0.0",
+    "recharts": "^2.5.0",
+    "next": "13.x",
+    "react": "18.x",
+    "react-dom": "18.x",
+    "tailwindcss": "^3.0.0",
+    "@headlessui/react": "^1.7.0",
+    "@heroicons/react": "^2.0.0",
+    "axios": "^1.0.0",
+    "zod": "^3.0.0",
+    "next-auth": "^4.0.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.0.0",
+    "@types/node": "^18.0.0",
+    "eslint": "^8.0.0",
+    "eslint-config-next": "^13.0.0",
+    "typescript": "^4.8.0",
+    "postcss": "^8.0.0",
+    "autoprefixer": "^10.0.0"
+  }
+}

--- a/novel-editor-app/postcss.config.js
+++ b/novel-editor-app/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/novel-editor-app/prisma/schema.prisma
+++ b/novel-editor-app/prisma/schema.prisma
@@ -1,0 +1,1 @@
+// Prisma schema placeholder

--- a/novel-editor-app/src/lib/api.ts
+++ b/novel-editor-app/src/lib/api.ts
@@ -1,0 +1,3 @@
+export async function fetchNovels() {
+  return []
+}

--- a/novel-editor-app/src/pages/_app.tsx
+++ b/novel-editor-app/src/pages/_app.tsx
@@ -1,0 +1,8 @@
+import '../styles/globals.css'
+import type { AppProps } from 'next/app'
+
+function MyApp({ Component, pageProps }: AppProps) {
+  return <Component {...pageProps} />
+}
+
+export default MyApp

--- a/novel-editor-app/src/pages/auth/login.tsx
+++ b/novel-editor-app/src/pages/auth/login.tsx
@@ -1,0 +1,12 @@
+import type { NextPage } from 'next'
+
+const LoginPage: NextPage = () => {
+  return (
+    <div className="p-4">
+      <h1 className="text-xl font-bold">Login</h1>
+      <p className="mt-2">Login form will be implemented here.</p>
+    </div>
+  )
+}
+
+export default LoginPage

--- a/novel-editor-app/src/pages/auth/signup.tsx
+++ b/novel-editor-app/src/pages/auth/signup.tsx
@@ -1,0 +1,12 @@
+import type { NextPage } from 'next'
+
+const SignupPage: NextPage = () => {
+  return (
+    <div className="p-4">
+      <h1 className="text-xl font-bold">Sign Up</h1>
+      <p className="mt-2">Sign up form will be implemented here.</p>
+    </div>
+  )
+}
+
+export default SignupPage

--- a/novel-editor-app/src/pages/characters/index.tsx
+++ b/novel-editor-app/src/pages/characters/index.tsx
@@ -1,0 +1,12 @@
+import type { NextPage } from 'next'
+
+const CharactersPage: NextPage = () => {
+  return (
+    <div className="p-4">
+      <h1 className="text-xl font-bold">Characters</h1>
+      <p className="mt-2">Character management will be implemented here.</p>
+    </div>
+  )
+}
+
+export default CharactersPage

--- a/novel-editor-app/src/pages/index.tsx
+++ b/novel-editor-app/src/pages/index.tsx
@@ -1,0 +1,12 @@
+import type { NextPage } from 'next'
+
+const Home: NextPage = () => {
+  return (
+    <div className="p-4">
+      <h1 className="text-2xl font-bold">Novel Editor</h1>
+      <p className="mt-2">Welcome to the Novel Editor application.</p>
+    </div>
+  )
+}
+
+export default Home

--- a/novel-editor-app/src/pages/novel/[id].tsx
+++ b/novel-editor-app/src/pages/novel/[id].tsx
@@ -1,0 +1,16 @@
+import type { NextPage } from 'next'
+import { useRouter } from 'next/router'
+
+const NovelDetail: NextPage = () => {
+  const router = useRouter()
+  const { id } = router.query
+
+  return (
+    <div className="p-4">
+      <h1 className="text-xl font-bold">Novel Detail {id}</h1>
+      <p className="mt-2">This page will show the novel contents.</p>
+    </div>
+  )
+}
+
+export default NovelDetail

--- a/novel-editor-app/src/pages/novel/edit/[id].tsx
+++ b/novel-editor-app/src/pages/novel/edit/[id].tsx
@@ -1,0 +1,16 @@
+import type { NextPage } from 'next'
+import { useRouter } from 'next/router'
+
+const NovelEditor: NextPage = () => {
+  const router = useRouter()
+  const { id } = router.query
+
+  return (
+    <div className="p-4">
+      <h1 className="text-xl font-bold">Edit Novel {id}</h1>
+      <p className="mt-2">Tiptap editor will be implemented here.</p>
+    </div>
+  )
+}
+
+export default NovelEditor

--- a/novel-editor-app/src/pages/worlds/index.tsx
+++ b/novel-editor-app/src/pages/worlds/index.tsx
@@ -1,0 +1,12 @@
+import type { NextPage } from 'next'
+
+const WorldsPage: NextPage = () => {
+  return (
+    <div className="p-4">
+      <h1 className="text-xl font-bold">World Settings</h1>
+      <p className="mt-2">World building tools will be implemented here.</p>
+    </div>
+  )
+}
+
+export default WorldsPage

--- a/novel-editor-app/src/styles/globals.css
+++ b/novel-editor-app/src/styles/globals.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/novel-editor-app/src/types/character.ts
+++ b/novel-editor-app/src/types/character.ts
@@ -1,0 +1,8 @@
+export interface Character {
+  id: string
+  userId: string
+  name: string
+  description: string
+  personality: string
+  diagnosisResult?: string
+}

--- a/novel-editor-app/src/types/novel.ts
+++ b/novel-editor-app/src/types/novel.ts
@@ -1,0 +1,8 @@
+export interface Novel {
+  id: string
+  userId: string
+  title: string
+  summary: string
+  createdAt: string
+  updatedAt: string
+}

--- a/novel-editor-app/src/types/world.ts
+++ b/novel-editor-app/src/types/world.ts
@@ -1,0 +1,8 @@
+export interface World {
+  id: string
+  userId: string
+  name: string
+  genre: string
+  summary: string
+  detailsJSON: string
+}

--- a/novel-editor-app/tailwind.config.js
+++ b/novel-editor-app/tailwind.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  content: ['./src/**/*.{js,ts,jsx,tsx}'],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}

--- a/novel-editor-app/tsconfig.json
+++ b/novel-editor-app/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve"
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- add README with project description
- scaffold Next.js project in `novel-editor-app` with basic pages
- include Tailwind and TypeScript configs

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c5ffbb638832db4b08eeecc723e7a