### PR TITLE
Fix TypeScript issues and import paths

### DIFF
--- a/src/components/characters/PersonalityDiagnoseModal.tsx
+++ b/src/components/characters/PersonalityDiagnoseModal.tsx
@@ -1,5 +1,5 @@
-import { Button } from "@/components/common/button";
-import { Card, CardContent } from "@/components/common/card";
+import { Button } from "@/components/common/Button";
+import { Card, CardContent } from "@/components/common/Card";
 import personalityMap from "@/data/personalityMap.json";
 import { useEffect, useState } from "react";
 import {
@@ -49,14 +49,23 @@ const template = {
   ],
 };
 
-function shuffleArray(array) {
+type Category = keyof typeof template;
+
+function shuffleArray<T>(array: T[]): T[] {
   return array
     .map((value) => ({ value, sort: Math.random() }))
     .sort((a, b) => a.sort - b.sort)
     .map(({ value }) => value);
 }
 
-const getRoleFromCSV = (base, decision, action, relation, value, data) => {
+const getRoleFromCSV = (
+  base: string,
+  decision: string,
+  action: string,
+  relation: string,
+  value: string,
+  data: any[]
+): { role: string; description: string } => {
   const row = data.find(
     (d) =>
       d["基本気質"] === base &&
@@ -74,7 +83,7 @@ const getRoleFromCSV = (base, decision, action, relation, value, data) => {
 };
 
 export default function PersonalityDiagnoseModal() {
-  const [shuffledQuestions, setShuffledQuestions] = useState([]);
+  const [shuffledQuestions, setShuffledQuestions] = useState<{ cat: string; idx: number; q: string }[]>([]);
   const [scores, setScores] = useState({
     base: 0,
     decision: 0,
@@ -82,19 +91,19 @@ export default function PersonalityDiagnoseModal() {
     relation: 0,
     value: 0,
   });
-  const [answers, setAnswers] = useState({});
-  const [result, setResult] = useState(null);
+  const [answers, setAnswers] = useState<Record<string, number[]>>({});
+  const [result, setResult] = useState<any>(null);
 
   useEffect(() => {
     const allQuestions = Object.entries(template).flatMap(([cat, questions]) =>
-      questions.map((q, idx) => ({ cat, idx, q }))
+      questions.map((q, idx) => ({ cat: cat as Category, idx, q }))
     );
     setShuffledQuestions(shuffleArray(allQuestions));
   }, []);
 
-  const handleCheck = (cat, idx) => {
+  const handleCheck = (cat: Category, idx: number) => {
     const updated = answers[cat]?.includes(idx)
-      ? answers[cat].filter((i) => i !== idx)
+      ? answers[cat].filter((i: number) => i !== idx)
       : [...(answers[cat] || []), idx];
     const normalized = Math.round((updated.length / template[cat].length) * 5);
     setAnswers({ ...answers, [cat]: updated });
@@ -159,7 +168,7 @@ export default function PersonalityDiagnoseModal() {
     <div className="max-w-2xl mx-auto p-4 space-y-6">
       <h1 className="text-2xl font-bold text-center">性格診断テスト</h1>
 
-      {shuffledQuestions.map(({ cat, idx, q }, displayIdx) => (
+      {shuffledQuestions.map(({ cat, idx, q }: { cat: Category; idx: number; q: string }, displayIdx: number) => (
         <label key={`${cat}-${idx}`} className="flex items-center space-x-2">
           <input
             type="checkbox"

--- a/src/components/common/Button.tsx
+++ b/src/components/common/Button.tsx
@@ -1,11 +1,20 @@
+import { ButtonHTMLAttributes, ReactNode } from "react";
+
+export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  children: ReactNode;
+  size?: "sm" | "md" | "lg";
+  className?: string;
+  onClick?: () => void;
+}
+
 export function Button({
   children,
   onClick,
   size = "md",
   className = "",
   ...props
-}) {
-  const sizes = {
+}: ButtonProps) {
+  const sizes: Record<"sm" | "md" | "lg", string> = {
     sm: "px-2 py-1 text-sm",
     md: "px-4 py-2",
     lg: "px-6 py-3 text-lg",

--- a/src/components/common/Card.tsx
+++ b/src/components/common/Card.tsx
@@ -1,4 +1,11 @@
-export function Card({ children, className = "" }) {
+import { ReactNode } from "react";
+
+export interface CardProps {
+  children: ReactNode;
+  className?: string;
+}
+
+export function Card({ children, className = "" }: CardProps) {
   return (
     <div className={`border rounded shadow p-4 bg-white ${className}`}>
       {children}
@@ -6,32 +13,6 @@ export function Card({ children, className = "" }) {
   );
 }
 
-export function CardContent({ children, className = "" }) {
+export function CardContent({ children, className = "" }: CardProps) {
   return <div className={className}>{children}</div>;
-}
-
-// components/ui/button.tsx
-
-export function Button({
-  children,
-  onClick,
-  size = "md",
-  className = "",
-  ...props
-}) {
-  const sizes = {
-    sm: "px-2 py-1 text-sm",
-    md: "px-4 py-2",
-    lg: "px-6 py-3 text-lg",
-  };
-
-  return (
-    <button
-      onClick={onClick}
-      className={`bg-blue-600 text-white rounded hover:bg-blue-700 ${sizes[size]} ${className}`}
-      {...props}
-    >
-      {children}
-    </button>
-  );
 }

--- a/src/components/common/Modal.tsx
+++ b/src/components/common/Modal.tsx
@@ -1,4 +1,11 @@
-export default function Modal({ children, onClose }) {
+import { ReactNode } from "react";
+
+interface ModalProps {
+  children: ReactNode;
+  onClose: () => void;
+}
+
+export default function Modal({ children, onClose }: ModalProps) {
   return (
     <div className="fixed inset-0 bg-black bg-opacity-50 flex justify-center items-center z-50">
       <div className="bg-white rounded shadow w-full max-w-2xl max-h-[66vh] overflow-y-auto p-4">

--- a/src/pages/characters/[id]/edit.tsx
+++ b/src/pages/characters/[id]/edit.tsx
@@ -1,5 +1,5 @@
 import PersonalityDiagnoseModal from "@/components/characters/PersonalityDiagnoseModal";
-import { Button } from "@/components/common/button";
+import { Button } from "@/components/common/Button";
 import Modal from "@/components/common/Modal";
 import axios from "axios";
 import { useRouter } from "next/router";
@@ -8,32 +8,32 @@ import { useEffect, useState } from "react";
 export default function CharacterEditPage() {
   const router = useRouter();
   const { id } = router.query;
-  const [character, setCharacter] = useState(null);
+  const [character, setCharacter] = useState<any>(null);
   const [showModal, setShowModal] = useState(false);
 
   useEffect(() => {
     if (id) {
       axios
         .get("/api/my-characters")
-        .then((res) => {
-          const found = res.data.find((c) => c.id === id);
+        .then((res: any) => {
+          const found = res.data.find((c: any) => c.id === id);
           if (found) setCharacter(found);
           else console.error("Character not found");
         })
-        .catch((err) => console.error(err));
+        .catch((err: any) => console.error(err));
     }
   }, [id]);
 
-  const handleChange = (e) => {
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { name, value } = e.target;
-    setCharacter((prev) => ({ ...prev, [name]: value }));
+    setCharacter((prev: any) => ({ ...prev, [name]: value }));
   };
 
   const handleSave = () => {
     axios
       .put(`/api/characters/${id}`, character)
       .then(() => router.push("/mypage/characters"))
-      .catch((err) => console.error(err));
+      .catch((err: any) => console.error(err));
   };
 
   const handleDiagnose = () => {

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,17 +1,17 @@
-import { Button } from "@/components/common/button";
-import { Card, CardContent } from "@/components/common/card";
+import { Button } from "@/components/common/Button";
+import { Card, CardContent } from "@/components/common/Card";
 import axios from "axios";
 import Link from "next/link";
 import { useEffect, useState } from "react";
 
 export default function HomePage() {
-  const [novels, setNovels] = useState([]);
+  const [novels, setNovels] = useState<any[]>([]);
 
   useEffect(() => {
     axios
       .get("/api/novels")
-      .then((res) => setNovels(res.data))
-      .catch((err) => console.error(err));
+      .then((res: any) => setNovels(res.data))
+      .catch((err: any) => console.error(err));
   }, []);
 
   return (
@@ -23,7 +23,7 @@ export default function HomePage() {
         </Link>
       </div>
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-        {novels.map((novel) => (
+        {novels.map((novel: any) => (
           <Card key={novel.id}>
             <CardContent className="space-y-2">
               <h2 className="text-xl font-semibold">{novel.title}</h2>

--- a/src/pages/mypage/characters.tsx
+++ b/src/pages/mypage/characters.tsx
@@ -1,28 +1,28 @@
-import { Button } from "@/components/common/button";
+import { Button } from "@/components/common/Button";
 import axios from "axios";
 import Link from "next/link";
 import { useEffect, useState } from "react";
 
 export default function MyCharactersPage() {
-  const [characters, setCharacters] = useState([]);
+  const [characters, setCharacters] = useState<any[]>([]);
 
   useEffect(() => {
     axios
       .get("/api/my-characters")
-      .then((res) => setCharacters(res.data))
-      .catch((err) => console.error(err));
+      .then((res: any) => setCharacters(res.data))
+      .catch((err: any) => console.error(err));
   }, []);
 
-  const handleDelete = (id) => {
+  const handleDelete = (id: string) => {
     if (confirm("本当に削除しますか？")) {
       axios
         .delete(`/api/characters/${id}`)
-        .then(() => setCharacters((prev) => prev.filter((c) => c.id !== id)))
-        .catch((err) => console.error(err));
+        .then(() => setCharacters((prev: any[]) => prev.filter((c: any) => c.id !== id)))
+        .catch((err: any) => console.error(err));
     }
   };
 
-  const handleDiagnose = (id) => {
+  const handleDiagnose = (id: string) => {
     // ここでPersonality CheckBox UIをモーダル起動する処理を書く
     alert(`診断UI起動: キャラID ${id}`);
   };
@@ -37,7 +37,7 @@ export default function MyCharactersPage() {
       </div>
 
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-        {characters.map((char) => (
+        {characters.map((char: any) => (
           <div key={char.id} className="bg-white shadow rounded p-4 space-y-2">
             <img
               src={char.imageUrl}

--- a/src/pages/mypage/index.tsx
+++ b/src/pages/mypage/index.tsx
@@ -1,4 +1,4 @@
-import { Button } from "@/components/common/button";
+import { Button } from "@/components/common/Button";
 import Link from "next/link";
 
 export default function MyPage() {

--- a/src/pages/mypage/novels.tsx
+++ b/src/pages/mypage/novels.tsx
@@ -1,24 +1,24 @@
-import { Button } from "@/components/common/button";
+import { Button } from "@/components/common/Button";
 import axios from "axios";
 import Link from "next/link";
 import { useEffect, useState } from "react";
 
 export default function MyNovelsPage() {
-  const [novels, setNovels] = useState([]);
+  const [novels, setNovels] = useState<any[]>([]);
 
   useEffect(() => {
     axios
       .get("/api/my-novels")
-      .then((res) => setNovels(res.data))
-      .catch((err) => console.error(err));
+      .then((res: any) => setNovels(res.data))
+      .catch((err: any) => console.error(err));
   }, []);
 
-  const handleDelete = (id) => {
+  const handleDelete = (id: string) => {
     if (confirm("本当に削除しますか？")) {
       axios
         .delete(`/api/novels/${id}`)
-        .then(() => setNovels((prev) => prev.filter((n) => n.id !== id)))
-        .catch((err) => console.error(err));
+        .then(() => setNovels((prev: any[]) => prev.filter((n: any) => n.id !== id)))
+        .catch((err: any) => console.error(err));
     }
   };
 
@@ -32,7 +32,7 @@ export default function MyNovelsPage() {
       </div>
 
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-        {novels.map((novel) => (
+        {novels.map((novel: any) => (
           <div key={novel.id} className="bg-white shadow rounded p-4 space-y-2">
             <h2 className="text-lg font-semibold">{novel.title}</h2>
             <p className="text-gray-600 text-sm">{novel.summary}</p>


### PR DESCRIPTION
## Summary
- fix casing of component imports
- tighten types for Button, Card, Modal and character personality modal
- clean up personality modal logic and annotate generics
- update pages to use explicit `any` types

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module 'react')*

------
https://chatgpt.com/codex/tasks/task_e_687e468dd0b4832dae6623bcb6af4407