### PR TITLE
Add Character type fields and apply typings

### DIFF
--- a/src/components/characters/CharacterForm.tsx
+++ b/src/components/characters/CharacterForm.tsx
@@ -1,8 +1,18 @@
 import ImagePreview from "@/components/common/ImagePreview";
 import SelectField from "@/components/common/SelectField";
 import TextField from "@/components/common/TextField";
+import { Character } from "@/types/character";
 
-export function CharacterForm({ character, onChange }: any) {
+interface CharacterFormProps {
+  character: Character;
+  onChange: (
+    e:
+      | React.ChangeEvent<HTMLInputElement | HTMLSelectElement>
+      | { target: { name: string; value: string | boolean } }
+  ) => void;
+}
+
+export function CharacterForm({ character, onChange }: CharacterFormProps) {
   return (
     <>
       <TextField

--- a/src/hooks/useCharacter.ts
+++ b/src/hooks/useCharacter.ts
@@ -1,10 +1,11 @@
 import axios from "axios";
 import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
+import { Character } from "@/types/character";
 
 export function useCharacter(id: string | string[] | undefined) {
   const router = useRouter();
-  const [character, setCharacter] = useState<any>(null);
+  const [character, setCharacter] = useState<Character | null>(null);
   const [chartData, setChartData] = useState<
     { category: string; score: number }[]
   >([]);
@@ -12,9 +13,9 @@ export function useCharacter(id: string | string[] | undefined) {
   useEffect(() => {
     if (id) {
       axios
-        .get("/api/my-characters")
-        .then((res: any) => {
-          const found = res.data.find((c: any) => c.id === id);
+        .get<Character[]>("/api/my-characters")
+        .then((res) => {
+          const found = res.data.find((c) => c.id === id);
           if (found) {
             setCharacter(found);
             setChartData([

--- a/src/pages/characters/[id]/edit.tsx
+++ b/src/pages/characters/[id]/edit.tsx
@@ -16,9 +16,13 @@ export default function CharacterEditPage() {
 
   if (!character) return <div className="text-center p-6">読み込み中...</div>;
 
-  const handleChange = (e: any) => {
-    const { name, value } = e.target;
-    setCharacter((prev: any) => ({ ...prev, [name]: value }));
+  const handleChange = (
+    e:
+      | React.ChangeEvent<HTMLInputElement | HTMLSelectElement>
+      | { target: { name: string; value: string | boolean } }
+  ) => {
+    const { name, value } = e.target as { name: string; value: any };
+    setCharacter((prev) => (prev ? { ...prev, [name]: value } : prev));
   };
 
   return (

--- a/src/pages/mypage/characters.tsx
+++ b/src/pages/mypage/characters.tsx
@@ -2,15 +2,16 @@ import { Button } from "@/components/common/Button";
 import axios from "axios";
 import Link from "next/link";
 import { useEffect, useState } from "react";
+import { Character } from "@/types/character";
 
 export default function MyCharactersPage() {
-  const [characters, setCharacters] = useState<any[]>([]);
+  const [characters, setCharacters] = useState<Character[]>([]);
 
   useEffect(() => {
     axios
-      .get("/api/my-characters")
-      .then((res: any) => setCharacters(res.data))
-      .catch((err: any) => console.error(err));
+      .get<Character[]>("/api/my-characters")
+      .then((res) => setCharacters(res.data))
+      .catch((err) => console.error(err));
   }, []);
 
   const handleDelete = (id: string) => {
@@ -18,9 +19,9 @@ export default function MyCharactersPage() {
       axios
         .delete(`/api/characters/${id}`)
         .then(() =>
-          setCharacters((prev: any[]) => prev.filter((c: any) => c.id !== id))
+          setCharacters((prev) => prev.filter((c) => c.id !== id))
         )
-        .catch((err: any) => console.error(err));
+        .catch((err) => console.error(err));
     }
   };
 

--- a/src/types/character.ts
+++ b/src/types/character.ts
@@ -2,7 +2,19 @@ export interface Character {
   id: string
   userId: string
   name: string
-  description: string
+  description?: string
   personality: string
+  role: string
+  corePersonality: string
+  actionPhilosophy: string
+  scores: {
+    base: number
+    decision: number
+    action: number
+    relation: number
+    value: number
+  }
+  isPublic: boolean
+  imageUrl: string
   diagnosisResult?: string
 }


### PR DESCRIPTION
## Summary
- expand `Character` interface to match API data
- type `CharacterForm` props
- use `Character` type across character hooks and pages

## Testing
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_6883a3ce5cb0832d981ab96d519aacd4